### PR TITLE
remove `transmute` of opaque type

### DIFF
--- a/src/optimizer/builder/allocator/usage.rs
+++ b/src/optimizer/builder/allocator/usage.rs
@@ -100,7 +100,7 @@ impl<I: Debug, V: Debug + Clone + Hash + Eq> Debug for Usage<I, V> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::util::{AsUsize};
+    use crate::util::AsUsize;
 
     // Returns usizes rather than Uses to simplify the callers.
     fn all_uses<I: Debug, V: Debug + Clone + Hash + Eq>(
@@ -108,7 +108,7 @@ mod tests {
         value: &V,
     ) -> Vec<usize> {
         let mut ret = Vec::new();
-        let mut head: Option<Use> = unsafe { std::mem::transmute(usage.first(value.clone())) };
+        let mut head: Option<Use> = usage.heads.get(value).cloned();
         while let Some(next) = head {
             ret.push(next.as_usize());
             head = usage.nexts[next.as_usize()].1;


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/101478 is a bugfix for the Rust compiler which will sadly break the tests for your crate as it contains the following pattern:
```rust
use std::mem::transmute;
fn foo() -> impl Sized {
    0u8
}

fn main() {
    // This compiling means that `main` is able to observe the concrete type
    // returned by `foo`.
    unsafe {
        transmute::<_, u8>(foo());
    }
}
```
An alternative fix to this PR would be to use `transmute_copy`, which does not check that the layouts match.

Apologies for the inconvenience :heart: